### PR TITLE
Create a special test config for webpack

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -1,0 +1,3 @@
+var env = process.env.NODE_ENV || 'development';
+
+module.exports = require('./webpack.config.' + env + '.babel.js');

--- a/webpack.config.test.babel.js
+++ b/webpack.config.test.babel.js
@@ -1,0 +1,6 @@
+import webpack from 'webpack';
+import config from './webpack.config.development.babel';
+
+process.env.BABEL_ENV = 'test';
+
+export default config;


### PR DESCRIPTION
## What Changed
- Adds a test config for webpack
## Why
- I had an issue with my react view tests failed with 

```
  Error: locals[0] does not appear to be a `module` object with Hot Module replacement API enabled. You should disable react-transform-hmr in production by using `env` section in
 Babel configuration. See the example in README: https://github.com/gaearon/react-transform-hmr
  at /Users/bemathis/Dev/JS/makers/src/log-in/LogIn-test.jsx:81653
```
