### PR TITLE
Fixes propType errors in HelloWord, adds breathing room to destructuring

### DIFF
--- a/src/hello-world/HelloWorld.jsx
+++ b/src/hello-world/HelloWorld.jsx
@@ -1,12 +1,17 @@
-import React from 'react';
-import {connect} from 'react-redux';
+import React, { PropTypes } from 'react';
+import { connect } from 'react-redux';
 
 import Greeting from './Greeting';
 import NameTaker from './NameTaker';
 
-import {setName} from './helloWorldActions';
+import { setName } from './helloWorldActions';
 
-const App = ({name, onSubmit}) => {
+const propTypes = {
+  name: PropTypes.string.isRequired,
+  onSubmit: PropTypes.func.isRequired
+};
+
+const App = ({ name, onSubmit }) => {
   return (
     <div>
       <Greeting name={name} />
@@ -14,6 +19,8 @@ const App = ({name, onSubmit}) => {
     </div>
   );
 };
+
+App.propTypes = propTypes;
 
 const mapStateToProps = (state) => {
   return {


### PR DESCRIPTION
### Why?
- `npm start` has errors on fresh install
- PropTypes validation is cool
- breathing room improves readability
### What?
- Adds proptypes constant near top of file for easy groking
- Attaches protypes to component
- Adds breathing room when destructuring
