### PR TITLE
Remove rule requiring all event handlers to start with 'handle'

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -239,7 +239,6 @@
     "react/jsx-curly-spacing": [2, "never"],            // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-spacing.md
     "react/jsx-equals-spacing": [2, "never"],           // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-equals-spacing.md
     "react/jsx-first-prop-new-line": [2, "multiline"],  // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-first-prop-new-line.md
-    "react/jsx-handler-names": 2,                       // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-handler-names.md
     "react/jsx-indent-props": [2, 2],                   // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-indent-props.md
     "react/jsx-indent": [2, 2],                         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-indent.md
     "react/jsx-key": 2,                                 // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-key.md


### PR DESCRIPTION
## Why?

It'd be super cool if all event handlers were named great, but this rule presents a problem when passing down action creators.

With the rule enforced, `onChangeText={this.props.actions.credentials.setUserEmail}` is an error. It would expect it to be `onChangeText={this.props.actions.credentials.handleSetUserEmail}`, which is kind of a crappy name for an action creator (they should be named for what they do, not what they handle -- there isn't necessarily any link between an action creator and what event fires to call that method).

Enforcing a method named `handleSetUserEmail` that was specific to this component would be very cool (like `onChangeText={this.handleSetUserEmail}`), but it isn't an option to have it not apply to methods that were passed down from another function.
## What changed?
- Removed this oppressive rule and made linting great again!
