### PR TITLE
Make all ESLint errors show up as warnings in the webpack loader

### DIFF
--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -12,9 +12,7 @@ module.exports = {
     filename: 'bundle.js'
   },
   module: {
-    preLoaders: [
-      {test: /\.jsx?$/, loader: 'eslint', exclude: /node_modules/}
-    ],
+    preLoaders: [],
     loaders: [
       {test: /\.jsx?$/, exclude: /node_modules/, loader: 'babel', query: { presets: ['stage-2', 'react', 'es2015'] }},
       {test: /\.css$/, loader: 'style'},
@@ -33,9 +31,6 @@ module.exports = {
       template: 'src/index.html'
     })
   ],
-  eslint: {
-    formatter: require('eslint-friendly-formatter')
-  },
   postcss: function(webpack) {
     return [
       require('postcss-import')({ addDependencyTo: webpack }),

--- a/webpack.config.development.js
+++ b/webpack.config.development.js
@@ -1,13 +1,22 @@
 var webpack = require('webpack');
 var config = require('./webpack.config.base');
 
-config.entry.unshift('webpack/hot/only-dev-server');
-config.entry.unshift('webpack-dev-server/client?http://localhost:8080');
-
 config.devServer = {
   hot: true,
   inline: true
 };
+
+config.entry.unshift('webpack/hot/only-dev-server');
+config.entry.unshift('webpack-dev-server/client?http://localhost:8080');
+
+config.eslint = {
+  emitWarning: true,
+  formatter: require('eslint-friendly-formatter')
+};
+
+config.module.preLoaders = config.module.preLoaders.concat([
+  { test: /\.jsx?$/, loader: 'eslint', exclude: /node_modules/ }
+]);
 
 config.plugins.unshift(new webpack.HotModuleReplacementPlugin());
 


### PR DESCRIPTION
## Why?
When hacking on code, the ESLint loader can be really, really persistent.

## What changed?
- Set up the ESLint loader to show any errors as warnings so that the build continues (will be helpful when hacking quickly and want to insert a debugger or temporarily skip a semicolon)
  - Will still be considered errors when running on TravisCI! :D
- Configured the ESLint loader to only run in development mode. It was previously running in production mode too, which is extra code that doesn't need to be in our bundle.js files