### PR TITLE
Add historyApiFallback so that browserHistory can be used in development

### DIFF
--- a/webpack.config.development.js
+++ b/webpack.config.development.js
@@ -2,6 +2,11 @@ var webpack = require('webpack');
 var config = require('./webpack.config.base');
 
 config.devServer = {
+  historyApiFallback: {
+    rewrites: [
+      { from: /^\/$/, to: 'index.html' }
+    ]
+  },
   hot: true,
   inline: true
 };


### PR DESCRIPTION
## Why?
Browser history is dope and we should use it on our projects and webpack-dev-server supports falling back to your index.html file so you can hit refresh when you're at `/sign-in` or `/user/19204/edit` and react-router will do its thing

## What changed?
- Added a fallback so routes not found serve the index file