### PR TITLE
Add initial layout of authentication components and redux actions/reducers

### DIFF
--- a/modules/authentication/actionTypes.js
+++ b/modules/authentication/actionTypes.js
@@ -1,0 +1,5 @@
+import keyMirror from 'keymirror';
+
+export default keyMirror({
+
+});

--- a/modules/authentication/actions.js
+++ b/modules/authentication/actions.js
@@ -1,0 +1,5 @@
+// import actionTypes from './actionTypes';
+
+export {
+
+};

--- a/modules/authentication/components/SignIn.jsx
+++ b/modules/authentication/components/SignIn.jsx
@@ -1,0 +1,26 @@
+import React, {
+  PropTypes
+} from 'react';
+
+const propTypes = {
+  actions: PropTypes.object
+};
+
+function SignIn() {
+  return (
+    <form>
+      <label htmlFor="email">
+        Email
+        <input name="email" type="text" />
+      </label>
+      <label htmlFor="password">
+        Password
+        <input name="password" type="password" />
+      </label>
+    </form>
+  );
+}
+
+SignIn.propTypes = propTypes;
+
+export default SignIn;

--- a/modules/authentication/containers/SignIn.jsx
+++ b/modules/authentication/containers/SignIn.jsx
@@ -1,0 +1,28 @@
+import {
+  connect
+} from 'react-redux';
+import {
+  bindActionCreators
+} from 'redux';
+import * as authenticationActions from '../actions';
+import SignIn from '../components/SignIn';
+
+function mapStateToProps(/* state */) {
+  return {
+
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    actions: {
+      authentication: bindActionCreators(authenticationActions, dispatch)
+    }
+  };
+}
+
+export {
+  mapStateToProps,
+  mapDispatchToProps
+};
+export default connect(mapStateToProps, mapDispatchToProps)(SignIn);

--- a/modules/authentication/interceptors.js
+++ b/modules/authentication/interceptors.js
@@ -1,0 +1,12 @@
+function addAuthenticationHeaders(config) {
+  return config;
+}
+
+function invalidateHeaders(error) {
+  throw error;
+}
+
+export {
+  addAuthenticationHeaders,
+  invalidateHeaders
+};

--- a/modules/authentication/reducer.js
+++ b/modules/authentication/reducer.js
@@ -1,0 +1,12 @@
+// import actionTypes from './actionTypes';
+
+const INITIAL_STATE = {};
+
+function authentication(state = INITIAL_STATE, action) {
+  switch (action.type) {
+  default:
+    return state;
+  }
+}
+
+export default authentication;

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "homepage": "https://github.com/smashingboxes/web-boilerplate#readme",
   "dependencies": {
     "axios": "^0.15.3",
+    "keymirror": "^0.1.1",
     "normalize.css": "^5.0.0",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",

--- a/src/Routes.jsx
+++ b/src/Routes.jsx
@@ -1,11 +1,17 @@
 import React from 'react';
-import { Route, Router, browserHistory as history } from 'react-router';
+import {
+  browserHistory as history,
+  Route,
+  Router
+} from 'react-router';
 import AppContainer from './containers/AppContainer';
+import SignIn from '../modules/authentication/containers/SignIn';
 
 function Routes() {
   return (
     <Router history={history}>
       <Route path="/" component={AppContainer} />
+      <Route path="/sign-in" component={SignIn} />
     </Router>
   );
 }

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,6 +1,8 @@
 import { combineReducers } from 'redux';
+import authentication from '../../modules/authentication/reducer';
 import helloWorld from './helloWorldReducer';
 
 export default combineReducers({
+  authentication,
   helloWorld
 });

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,8 +1,16 @@
 import axios from 'axios';
+import {
+  addAuthenticationHeaders,
+  invalidateHeaders
+} from '../../modules/authentication/interceptors';
 
 function init() {
   const api = axios.create();
+
   // Transforms and interceptors can go here
+  api.interceptors.request.use(addAuthenticationHeaders);
+  api.interceptors.response.use((res) => res, invalidateHeaders);
+
   return api;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3004,6 +3004,10 @@ jsx-ast-utils@^1.3.4:
     acorn-jsx "^3.0.1"
     object-assign "^4.1.0"
 
+keymirror@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/keymirror/-/keymirror-0.1.1.tgz#918889ea13f8d0a42e7c557250eee713adc95c35"
+
 kind-of@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.1.0.tgz#475d698a5e49ff5e53d14e3e732429dc8bf4cf47"


### PR DESCRIPTION
## Why?
We're building a reusable module that lets us easily reuse sign in, registration, reset password stuff across projects. This is the initial commit to that project.

## What changed?
- Added a couple very basic containers and components involved with sign in
- Added the skeleton of the redux actions and reducers involved with sign in
- Wired these components and redux actions from the authentication module into the basic boilerplate for our development purposes