### PR TITLE
Update scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "lint:css": "stylelint 'src/css/**/*.css' || true",
     "lint:js": "eslint --format 'node_modules/eslint-friendly-formatter' --ext .js,.jsx ./src",
     "lint:dev": "npm run lint -- -w",
-    "pretest": "npm run lint:css && npm run lint:js",
     "test": "NODE_ENV=test mocha --compilers jsx:babel-register --opts 'support/mocha.opts' 'src/**/*.spec.*'",
     "test:dev": "npm test -- -w",
     "build": "webpack -d --progress --colors",


### PR DESCRIPTION
#### Why
Because running the linter before running tests is so annoying. I think linting is great but it's something to do before you push up code, not while you're continuously changing code.

#### What
- Removed `pretest` script