### PR TITLE
Add ability to sign out from the app/backend

### DIFF
--- a/modules/authentication/actions.js
+++ b/modules/authentication/actions.js
@@ -105,6 +105,19 @@ function signIn(credentials) {
   };
 }
 
+function signOut() {
+  const signOutAction = {
+    type: actionTypes.SIGN_OUT
+  };
+
+  return function(dispatch) {
+    return service
+      .signOut()
+      .then(() => dispatch(signOutAction))
+      .catch(() => dispatch(signOutAction));
+  };
+}
+
 function updateTokenInfo(tokenInfo) {
   return {
     type: actionTypes.UPDATE_TOKEN_INFO,
@@ -116,5 +129,6 @@ export {
   register,
   requestPasswordReset,
   signIn,
+  signOut,
   updateTokenInfo
 };

--- a/modules/authentication/actions.spec.js
+++ b/modules/authentication/actions.spec.js
@@ -290,7 +290,62 @@ describe('authentication/actions', function() {
     });
   });
 
-  describe('UPDATE_TOKEN_INFO', function() {
+  describe('signOut', function() {
+    let dispatch;
+
+    beforeEach(function() {
+      dispatch = this.sandbox.stub();
+    });
+
+    context('the user successfully signed out of the server', function() {
+      let promise;
+      let signOut;
+
+      beforeEach(function() {
+        signOut = this.sandbox.stub(service, 'signOut', () => Promise.resolve());
+
+        promise = actions.signOut()(dispatch);
+      });
+
+      it('signs the user out of the server', function() {
+        expect(signOut.calledOnce).to.be.true;
+      });
+
+      it('dispatches a sign out action', function() {
+        return promise.then(() => {
+          expect(dispatch.calledOnce).to.be.true;
+          const [action] = dispatch.firstCall.args;
+          expect(action).to.deep.equal({
+            type: 'SIGN_OUT'
+          });
+        });
+      });
+    });
+
+    context('there was a problem signing out with the server', function() {
+      let promise;
+
+      beforeEach(function() {
+        this.sandbox.stub(service, 'signOut', () => Promise.reject());
+
+        promise = actions.signOut()(dispatch);
+      });
+
+      it('dispatches a sign out action after the request fails so the user is still signed out locally', function() {
+        return promise
+          .then(expect.fail)
+          .catch(() => {
+            expect(dispatch.calledOnce).to.be.true;
+            const [action] = dispatch.firstCall.args;
+            expect(action).to.deep.equal({
+              type: 'SIGN_OUT'
+            });
+          });
+      });
+    });
+  });
+
+  describe('updateTokenInfo', function() {
     let action;
     let expectedTokenInfo;
 

--- a/modules/authentication/components/SignOut.jsx
+++ b/modules/authentication/components/SignOut.jsx
@@ -1,0 +1,27 @@
+import React, {
+  PropTypes
+} from 'react';
+
+const propTypes = {
+  actions: PropTypes.shape({
+    authentication: PropTypes.shape({
+      signOut: PropTypes.func.isRequired
+    }).isRequired
+  }).isRequired,
+  router: PropTypes.shape({
+    push: PropTypes.func.isRequired
+  }).isRequired
+};
+
+function SignOut({ actions, router }) {
+  function handleSignOut() {
+    actions.authentication.signOut();
+    router.push('/sign-in');
+  }
+
+  return <a onClick={handleSignOut}>Sign Out</a>;
+}
+
+SignOut.propTypes = propTypes;
+
+export default SignOut;

--- a/modules/authentication/components/SignOut.spec.jsx
+++ b/modules/authentication/components/SignOut.spec.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import SignOut from './SignOut';
+
+describe('<SignOut />', function() {
+  let props;
+
+  beforeEach(function() {
+    this.sandbox = sandbox.create();
+    props = {
+      actions: {
+        authentication: {
+          signOut: this.sandbox.stub()
+        }
+      },
+      router: {
+        push: this.sandbox.stub()
+      }
+    };
+  });
+
+  afterEach(function() {
+    this.sandbox.restore();
+  });
+
+  describe('handleSignOut', function() {
+    let signOut;
+
+    beforeEach(function() {
+      signOut = shallow(<SignOut {...props} />);
+      signOut.prop('onClick')();
+    });
+
+    it('signs the user out', function() {
+      expect(props.actions.authentication.signOut.calledOnce).to.be.true;
+    });
+
+    it('navigates to the sign in link', function() {
+      expect(props.router.push.calledOnce).to.be.true;
+      const [endpoint] = props.router.push.firstCall.args;
+      expect(endpoint).to.equal('/sign-in');
+    });
+  });
+});

--- a/modules/authentication/constants/actionTypes.js
+++ b/modules/authentication/constants/actionTypes.js
@@ -13,5 +13,7 @@ export default keyMirror({
   SIGN_IN_SUCCESS: null,
   SIGN_IN_FAILURE: null,
 
+  SIGN_OUT: null,
+
   UPDATE_TOKEN_INFO: null
 });

--- a/modules/authentication/containers/SignOut.js
+++ b/modules/authentication/containers/SignOut.js
@@ -1,0 +1,21 @@
+import {
+  connect
+} from 'react-redux';
+import {
+  bindActionCreators
+} from 'redux';
+import * as authenticationActions from '../actions';
+import SignOut from '../components/SignOut';
+
+function mapDispatchToProps(dispatch) {
+  return {
+    actions: {
+      authentication: bindActionCreators(authenticationActions, dispatch)
+    }
+  };
+}
+
+export {
+  mapDispatchToProps
+};
+export default connect(null, mapDispatchToProps)(SignOut);

--- a/modules/authentication/containers/SignOut.spec.js
+++ b/modules/authentication/containers/SignOut.spec.js
@@ -1,0 +1,37 @@
+import * as redux from 'redux';
+import * as authenticationActionCreators from '../actions';
+import {
+  mapDispatchToProps
+} from './SignOut';
+
+describe('SignOut container', function() {
+  beforeEach(function() {
+    this.sandbox = sandbox.create();
+  });
+
+  afterEach(function() {
+    this.sandbox.restore();
+  });
+
+  describe('mapDispatchToProps', function() {
+    let bindActionCreators;
+    let expectedActionCreators;
+    let expectedDispatch;
+    let props;
+
+    beforeEach(function() {
+      expectedActionCreators = { [faker.lorem.word()]: this.sandbox.stub() };
+      bindActionCreators = this.sandbox.stub(redux, 'bindActionCreators').returns(expectedActionCreators);
+      expectedDispatch = this.sandbox.stub();
+      props = mapDispatchToProps(expectedDispatch);
+    });
+
+    it('binds the authentication action creators to the props', function() {
+      expect(bindActionCreators.called).to.be.true;
+      const [actionCreators, dispatch] = bindActionCreators.firstCall.args;
+      expect(actionCreators).to.equal(authenticationActionCreators);
+      expect(dispatch).to.equal(expectedDispatch);
+      expect(props.actions.authentication).to.equal(expectedActionCreators);
+    });
+  });
+});

--- a/modules/authentication/reducer.js
+++ b/modules/authentication/reducer.js
@@ -41,6 +41,16 @@ function authentication(state = INITIAL_STATE, action) {
       isActive: false
     };
 
+  case actionTypes.SIGN_OUT:
+    return {
+      ...state,
+      email: null,
+      id: null,
+      name: null,
+      uid: null,
+      tokenInfo: {}
+    };
+
   case actionTypes.UPDATE_TOKEN_INFO:
     return {
       ...state,

--- a/modules/authentication/reducer.spec.js
+++ b/modules/authentication/reducer.spec.js
@@ -154,6 +154,43 @@ describe('authentication/reducer', function() {
     });
   });
 
+  describe('SIGN_OUT', function() {
+    let nextState;
+    let previousState;
+
+    beforeEach(function() {
+      previousState = {
+        avatar: faker.internet.avatar(),
+        email: faker.internet.email(),
+        id: faker.random.number().toString(),
+        password: faker.internet.password(),
+        name: faker.name.findName(),
+        uid: faker.internet.email(),
+        tokenInfo: VALID_TOKEN_INFO_FIELDS.reduce((memo, field) => {
+          memo[field] = faker.internet.password();
+          return memo;
+        }, {})
+      };
+      nextState = reducer(previousState, {
+        type: 'SIGN_OUT'
+      });
+    });
+
+    it('clears any existing user info', function() {
+      expect(nextState.email).to.be.null;
+      expect(nextState.id).to.be.null;
+      expect(nextState.name).to.be.null;
+      expect(nextState.uid).to.be.null;
+      expect(nextState.tokenInfo).to.deep.equal({});
+    });
+
+    it('creates a new object and transfers the old properties', function() {
+      expect(nextState).to.not.equal(previousState);
+      expect(nextState.avatar).to.equal(previousState.avatar);
+      expect(nextState.password).to.equal(previousState.password);
+    });
+  });
+
   describe('UPDATE_TOKEN_INFO', function() {
     let expectedTokenInfo;
     let nextState;

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -2,15 +2,20 @@ import React, { PropTypes } from 'react';
 
 import Greeting from './Greeting';
 import NameTaker from './NameTaker';
+import SignOut from '../../modules/authentication/containers/SignOut';
 
 const propTypes = {
   name: PropTypes.string.isRequired,
-  onSubmit: PropTypes.func.isRequired
+  onSubmit: PropTypes.func.isRequired,
+  router: PropTypes.object.isRequired,
+  tokenInfo: PropTypes.object.isRequired
 };
 
-function App({ name, onSubmit }) {
+function App({ name, onSubmit, router, tokenInfo }) {
   return (
     <div>
+      {Object.keys(tokenInfo).length > 0 &&
+        <SignOut router={router} />}
       <Greeting name={name} />
       <NameTaker name={name} onSubmit={onSubmit} />
     </div>

--- a/src/containers/AppContainer.js
+++ b/src/containers/AppContainer.js
@@ -4,7 +4,8 @@ import App from '../components/App';
 
 function mapStateToProps(state) {
   return {
-    ...state.helloWorld
+    ...state.helloWorld,
+    tokenInfo: state.authentication.tokenInfo
   };
 }
 


### PR DESCRIPTION
## What changed?
- Added actions, component, and reducer for Signing Out of the boilerplate app/backend
- Added SignOut component to the main app screen