### PR TITLE
Lock out protected routes to unauthorized users

### DIFF
--- a/modules/authentication/services/index.js
+++ b/modules/authentication/services/index.js
@@ -1,4 +1,37 @@
 import apiService from '../../../src/services/api';
+import {
+  VALID_TOKEN_INFO_FIELDS
+} from '../constants';
+
+function checkAuth(store) {
+  return function(nextState, replace, callback) {
+    return store.getHydratedState()
+      .then((state) => {
+        const hasAllTokenInfoKeys = VALID_TOKEN_INFO_FIELDS.filter((field) => {
+          return state.authentication.tokenInfo[field];
+        }).length === VALID_TOKEN_INFO_FIELDS.length;
+
+        if (!hasAllTokenInfoKeys) {
+          throw new Error();
+        }
+
+        callback();
+      })
+      .catch(() => {
+        const query = { ...nextState.location.query };
+
+        if (nextState.location.pathname && nextState.location.pathname !== '/') {
+          query.next = nextState.location.pathname;
+        }
+
+        replace({
+          query,
+          pathname: '/sign-in'
+        });
+        callback();
+      });
+  };
+}
 
 function register(credentials) {
   return apiService
@@ -84,6 +117,7 @@ function signOut() {
 }
 
 export default {
+  checkAuth,
   register,
   requestPasswordReset,
   resetPassword,

--- a/src/Routes.jsx
+++ b/src/Routes.jsx
@@ -1,19 +1,31 @@
-import React from 'react';
+import React, {
+  PropTypes
+} from 'react';
 import {
   browserHistory as history,
+  IndexRoute,
   Route,
   Router
 } from 'react-router';
 import AppContainer from './containers/AppContainer';
 import SignIn from '../modules/authentication/containers/SignIn';
+import authenticationService from '../modules/authentication/services';
 
-function Routes() {
+const propTypes = {
+  store: PropTypes.object.isRequired
+};
+
+function Routes({ store }) {
   return (
     <Router history={history}>
-      <Route path="/" component={AppContainer} />
+      <Route path="/" onEnter={authenticationService.checkAuth(store)}>
+        <IndexRoute component={AppContainer} />
+      </Route>
       <Route path="/sign-in" component={SignIn} />
     </Router>
   );
 }
+
+Routes.propTypes = propTypes;
 
 export default Routes;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -11,7 +11,7 @@ let render = () => {
   const Routes = require('./Routes').default;
   ReactDOM.render(
     <Provider store={store.getStore()}>
-      <Routes />
+      <Routes store={store} />
     </Provider>,
     rootEl
   );


### PR DESCRIPTION
## Why?
Most of the apps we build need to be actually protected behind an auth wall, not just allow the user to authenticate.

## What changed?
- Added service that integrates with React Router to check if the user is authenticated
- Wired this service into the regular boilerplate

## Notes
This works with React Router v3 -- v4 changes stuff quite a bit and we need a different strategy for that. The boilerplate is locked to v3 at the moment, so going this direction for now.