### PR TITLE
feature/authentication-module/update invalidate headers

### DIFF
--- a/modules/authentication/Interceptors.js
+++ b/modules/authentication/Interceptors.js
@@ -1,5 +1,5 @@
 import {
-  signOutSuccess,
+  clearHeaders,
   updateTokenInfo
 } from './actions';
 import {
@@ -29,7 +29,7 @@ class Interceptors {
   invalidateHeaders(error) {
     if (error.response.status === 401) {
       const store = this.store.getStore();
-      store.dispatch(signOutSuccess());
+      store.dispatch(clearHeaders());
     }
 
     throw error;

--- a/modules/authentication/Interceptors.js
+++ b/modules/authentication/Interceptors.js
@@ -1,4 +1,5 @@
 import {
+  signOutSuccess,
   updateTokenInfo
 } from './actions';
 import {
@@ -26,6 +27,11 @@ class Interceptors {
   }
 
   invalidateHeaders(error) {
+    if (error.response.status === 401) {
+      const store = this.store.getStore();
+      store.dispatch(signOutSuccess());
+    }
+
     throw error;
   }
 

--- a/modules/authentication/Interceptors.spec.js
+++ b/modules/authentication/Interceptors.spec.js
@@ -115,7 +115,7 @@ describe('authentication/Interceptors', function() {
 
       expect(dispatch.calledOnce).to.be.true;
       expect(dispatch.firstCall.args[0]).to.deep.equal({
-        type: 'SIGN_OUT'
+        type: 'CLEAR_HEADERS'
       });
     });
 

--- a/modules/authentication/Interceptors.spec.js
+++ b/modules/authentication/Interceptors.spec.js
@@ -92,7 +92,42 @@ describe('authentication/Interceptors', function() {
   });
 
   describe('invalidateHeaders', function() {
-    it('invalidates');
+    let dispatch;
+    let interceptors;
+    let store;
+
+    beforeEach(function() {
+      dispatch = this.sandbox.stub();
+      store = {
+        getStore: this.sandbox.spy(() => {
+          return { dispatch };
+        })
+      };
+      interceptors = new Interceptors(store);
+    });
+
+    it('dispatches a sign out action on a 401 error', function() {
+      const expectedError = new Error();
+      expectedError.response = { status: 401 };
+      expect(() => {
+        interceptors.invalidateHeaders(expectedError);
+      }).to.throw(expectedError);
+
+      expect(dispatch.calledOnce).to.be.true;
+      expect(dispatch.firstCall.args[0]).to.deep.equal({
+        type: 'SIGN_OUT'
+      });
+    });
+
+    it('does not dispatch a sign out action on a non-401 error', function() {
+      const expectedError = new Error();
+      expectedError.response = {};
+      expect(() => {
+        interceptors.invalidateHeaders(expectedError);
+      }).to.throw(expectedError);
+
+      expect(dispatch.called).to.be.false;
+    });
   });
 
   describe('isNewToken', function() {

--- a/modules/authentication/actions.js
+++ b/modules/authentication/actions.js
@@ -98,6 +98,12 @@ function signInFailure(err) {
   };
 }
 
+function signOutSuccess() {
+  return {
+    type: actionTypes.SIGN_OUT
+  };
+}
+
 function requestPasswordReset(credentials) {
   return function(dispatch) {
     dispatch(requestPasswordResetStart());
@@ -141,15 +147,11 @@ function signIn(credentials) {
 }
 
 function signOut() {
-  const signOutAction = {
-    type: actionTypes.SIGN_OUT
-  };
-
   return function(dispatch) {
     return service
       .signOut()
-      .then(() => dispatch(signOutAction))
-      .catch(() => dispatch(signOutAction));
+      .then(() => dispatch(signOutSuccess()))
+      .catch(() => dispatch(signOutSuccess()));
   };
 }
 
@@ -166,5 +168,6 @@ export {
   resetPassword,
   signIn,
   signOut,
+  signOutSuccess,
   updateTokenInfo
 };

--- a/modules/authentication/actions.js
+++ b/modules/authentication/actions.js
@@ -1,6 +1,12 @@
 import actionTypes from './constants/actionTypes';
 import service from './services';
 
+function clearHeaders() {
+  return {
+    type: actionTypes.CLEAR_HEADERS
+  };
+}
+
 function registerStart() {
   return {
     type: actionTypes.REGISTER_START
@@ -98,12 +104,6 @@ function signInFailure(err) {
   };
 }
 
-function signOutSuccess() {
-  return {
-    type: actionTypes.SIGN_OUT
-  };
-}
-
 function requestPasswordReset(credentials) {
   return function(dispatch) {
     dispatch(requestPasswordResetStart());
@@ -147,11 +147,15 @@ function signIn(credentials) {
 }
 
 function signOut() {
+  const signOutAction = {
+    type: actionTypes.SIGN_OUT
+  };
+
   return function(dispatch) {
     return service
       .signOut()
-      .then(() => dispatch(signOutSuccess()))
-      .catch(() => dispatch(signOutSuccess()));
+      .then(() => dispatch(signOutAction))
+      .catch(() => dispatch(signOutAction));
   };
 }
 
@@ -163,11 +167,11 @@ function updateTokenInfo(tokenInfo) {
 }
 
 export {
+  clearHeaders,
   register,
   requestPasswordReset,
   resetPassword,
   signIn,
   signOut,
-  signOutSuccess,
   updateTokenInfo
 };

--- a/modules/authentication/actions.spec.js
+++ b/modules/authentication/actions.spec.js
@@ -13,6 +13,20 @@ describe('authentication/actions', function() {
     this.sandbox.restore();
   });
 
+  describe('clearHeaders', function() {
+    let clearHeaders;
+
+    beforeEach(function() {
+      clearHeaders = actions.clearHeaders();
+    });
+
+    it('returns a clear headers action', function() {
+      expect(clearHeaders).to.deep.equal({
+        type: 'CLEAR_HEADERS'
+      });
+    });
+  });
+
   describe('register', function() {
     context('a successful request', function() {
       let dispatch;

--- a/modules/authentication/constants/actionTypes.js
+++ b/modules/authentication/constants/actionTypes.js
@@ -1,6 +1,8 @@
 import keyMirror from 'keymirror';
 
 export default keyMirror({
+  CLEAR_HEADERS: null,
+
   REGISTER_FAILURE: null,
   REGISTER_START: null,
   REGISTER_SUCCESS: null,

--- a/modules/authentication/reducer.js
+++ b/modules/authentication/reducer.js
@@ -12,6 +12,17 @@ const INITIAL_STATE = {
 
 function authentication(state = INITIAL_STATE, action) {
   switch (action.type) {
+  case actionTypes.CLEAR_HEADERS:
+  case actionTypes.SIGN_OUT:
+    return {
+      ...state,
+      email: null,
+      id: null,
+      name: null,
+      uid: null,
+      tokenInfo: {}
+    };
+
   case actionTypes.REGISTER_START:
   case actionTypes.RESET_PASSWORD_START:
   case actionTypes.SIGN_IN_START:
@@ -65,16 +76,6 @@ function authentication(state = INITIAL_STATE, action) {
       ...state,
       error: action.payload,
       isActive: false
-    };
-
-  case actionTypes.SIGN_OUT:
-    return {
-      ...state,
-      email: null,
-      id: null,
-      name: null,
-      uid: null,
-      tokenInfo: {}
     };
 
   case actionTypes.UPDATE_TOKEN_INFO:

--- a/modules/authentication/reducer.spec.js
+++ b/modules/authentication/reducer.spec.js
@@ -14,9 +14,46 @@ const initialState = {
 };
 
 describe('authentication/reducer', function() {
-  const testCases = ['REGISTER', 'RESET_PASSWORD', 'SIGN_IN'];
+  ['CLEAR_HEADERS', 'SIGN_OUT'].forEach(function(testCase) {
+    describe(testCase, function() {
+      let nextState;
+      let previousState;
 
-  testCases.forEach(function(testCase) {
+      beforeEach(function() {
+        previousState = {
+          avatar: faker.internet.avatar(),
+          email: faker.internet.email(),
+          id: faker.random.number().toString(),
+          password: faker.internet.password(),
+          name: faker.name.findName(),
+          uid: faker.internet.email(),
+          tokenInfo: VALID_TOKEN_INFO_FIELDS.reduce((memo, field) => {
+            memo[field] = faker.internet.password();
+            return memo;
+          }, {})
+        };
+        nextState = reducer(previousState, {
+          type: testCase
+        });
+      });
+
+      it('clears any existing user info', function() {
+        expect(nextState.email).to.be.null;
+        expect(nextState.id).to.be.null;
+        expect(nextState.name).to.be.null;
+        expect(nextState.uid).to.be.null;
+        expect(nextState.tokenInfo).to.deep.equal({});
+      });
+
+      it('creates a new object and transfers the old properties', function() {
+        expect(nextState).to.not.equal(previousState);
+        expect(nextState.avatar).to.equal(previousState.avatar);
+        expect(nextState.password).to.equal(previousState.password);
+      });
+    });
+  });
+
+  ['REGISTER', 'RESET_PASSWORD', 'SIGN_IN'].forEach(function(testCase) {
     describe(`${testCase}_START`, function() {
       let nextState;
       let previousState;
@@ -243,43 +280,6 @@ describe('authentication/reducer', function() {
     it('creates a new object and transfers the old properties', function() {
       expect(nextState).to.not.equal(previousState);
       expect(nextState.avatar).to.equal(previousState.avatar);
-    });
-  });
-
-  describe('SIGN_OUT', function() {
-    let nextState;
-    let previousState;
-
-    beforeEach(function() {
-      previousState = {
-        avatar: faker.internet.avatar(),
-        email: faker.internet.email(),
-        id: faker.random.number().toString(),
-        password: faker.internet.password(),
-        name: faker.name.findName(),
-        uid: faker.internet.email(),
-        tokenInfo: VALID_TOKEN_INFO_FIELDS.reduce((memo, field) => {
-          memo[field] = faker.internet.password();
-          return memo;
-        }, {})
-      };
-      nextState = reducer(previousState, {
-        type: 'SIGN_OUT'
-      });
-    });
-
-    it('clears any existing user info', function() {
-      expect(nextState.email).to.be.null;
-      expect(nextState.id).to.be.null;
-      expect(nextState.name).to.be.null;
-      expect(nextState.uid).to.be.null;
-      expect(nextState.tokenInfo).to.deep.equal({});
-    });
-
-    it('creates a new object and transfers the old properties', function() {
-      expect(nextState).to.not.equal(previousState);
-      expect(nextState.avatar).to.equal(previousState.avatar);
-      expect(nextState.password).to.equal(previousState.password);
     });
   });
 


### PR DESCRIPTION
#### Why
Because these are common copy-and-paste features on front end projects.

#### What
- Added more functionality to `invalidateHeaders`
- Separated `signOut` action functionality so part of it can be used in the interceptor