### PR TITLE
Add the viewport meta tag so it resizes properly on the phone

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Smashing Boxes - Web Boilerplate</title>
   </head>
   <body>


### PR DESCRIPTION
## Why?

* This should be our default because 99% of apps want it this way.

## What Changed?

* Added the viewport meta tag.