### PR TITLE
Moving the webpack-dev-middleware to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
     "react-router": "^3.0.0",
     "redux": "^3.6.0",
     "redux-thunk": "^2.1.0",
-    "sanitize.css": "^4.1.0",
-    "webpack-dev-middleware": "^1.10.1"
+    "sanitize.css": "^4.1.0"
   },
   "devDependencies": {
     "babel-core": "^6.21.0",
@@ -79,6 +78,7 @@
     "stylelint": "^7.7.0",
     "url-loader": "^0.5.7",
     "webpack": "^2.3.3",
+    "webpack-dev-middleware": "^1.10.1",
     "webpack-dev-server": "^2.4.2",
     "webpack-hot-middleware": "^2.16.1"
   }


### PR DESCRIPTION
# WHY?

- The `webpack-dev-middleware` package was in the `dependencies` section of `package.json` instead of `devDependencies`.

# WHAT?

- Moved `webpack-dev-middleware` from `dependencies` to `devDependencies`