### PR TITLE
For production, split code between vendor, app, and manifest file, inline the manifest file

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "faker": "^3.1.0",
     "file-loader": "^0.9.0",
     "html-webpack-plugin": "^2.28.0",
+    "inline-manifest-webpack-plugin": "^3.0.1",
     "json-loader": "^0.5.4",
     "lolex": "^1.5.2",
     "mocha": "^3.2.0",

--- a/src/index.html
+++ b/src/index.html
@@ -7,6 +7,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <%=htmlWebpackPlugin.files.webpackManifest%>
+    <%= htmlWebpackPlugin.files.webpackManifest %>
   </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -7,5 +7,6 @@
   </head>
   <body>
     <div id="root"></div>
+    <%=htmlWebpackPlugin.files.webpackManifest%>
   </body>
 </html>

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -6,10 +6,12 @@ module.exports = {
   resolve: {
     extensions: ['.js', '.jsx', '.json']
   },
-  entry: ['./src/index.jsx'],
+  entry: {
+    bundle: './src/index.jsx'
+  },
   output: {
     path: path.join(__dirname, 'dist'),
-    filename: 'bundle.js'
+    filename: '[name].js'
   },
   module: {
     rules: [{

--- a/webpack.config.production.js
+++ b/webpack.config.production.js
@@ -1,14 +1,24 @@
 var webpack = require('webpack');
+var InlineManifestWebpackPlugin = require('inline-manifest-webpack-plugin');
 var config = require('./webpack.config.base');
 
 config.bail = true;
 config.profile = false;
 config.devtool = 'source-map';
+config.output.filename = '[name].[chunkhash].js';
 
 config.plugins = config.plugins.concat([
   new webpack.LoaderOptionsPlugin({
     debug: true
   }),
+  new webpack.optimize.CommonsChunkPlugin({
+    name: 'vendor',
+    minChunks: (module) => {
+      return module.context && module.context.indexOf('node_modules') !== -1;
+    }
+  }),
+  new webpack.optimize.CommonsChunkPlugin({ name: 'manifest' }),
+  new InlineManifestWebpackPlugin({ name: 'webpackManifest' }),
   new webpack.optimize.UglifyJsPlugin({
     compress: {
       warnings: false

--- a/webpack.config.production.js
+++ b/webpack.config.production.js
@@ -13,7 +13,7 @@ config.plugins = config.plugins.concat([
   }),
   new webpack.optimize.CommonsChunkPlugin({
     name: 'vendor',
-    minChunks: (module) => {
+    minChunks: function(module) {
       return module.context && module.context.indexOf('node_modules') !== -1;
     }
   }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2803,6 +2803,12 @@ ini@~1.3.0:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
 
+inline-manifest-webpack-plugin@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/inline-manifest-webpack-plugin/-/inline-manifest-webpack-plugin-3.0.1.tgz#ca2151063115298e2fd94b669ab76c7dd63e44ad"
+  dependencies:
+    source-map-url "0.4.0"
+
 inquirer@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-0.12.0.tgz#1ef2bfd63504df0bc75785fff8c2c41df12f077e"
@@ -5314,6 +5320,10 @@ source-map-support@^0.4.2:
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.7.tgz#7a7988e0e66241c778c78dd179199bb6bcd35bd6"
   dependencies:
     source-map "^0.5.3"
+
+source-map-url@0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
 
 source-map-url@~0.3.0:
   version "0.3.0"


### PR DESCRIPTION
# WHY?

When building for production, we should utilize common chunks and split out the vendor files from the application for caching purposes. Additionally, since `webpack` inserts its own runtime code in every build, we should chunk that out as well, which we can inline to save an HTTP request.

# WHAT?

- Used the CommonChunks plugin to first split out all vendor files used from `node_modules` into a `vendors.js` file.
- Additionally split out the `webpack` runtime code (which changes and updates on every build) into its own `manifest.js` file since this would also cause the `vendor.js` file to change and prevent it from caching.
- Added a plugin to inline the `manifest.js` file to save an HTTP request.
- Added the `chunkhash` which will update when the code changes and cache-bust when necessary.

Note: Since the `chunkhash` will only change when the chunk changes, the `chunkhash` for the `vendor` will only change if you pull in or decide not to use modules. Whereas the `chunkhash` for the `bundle` will update when the application code is changed.