### PR TITLE
feature/add proxy to server

### DIFF
--- a/webpack.config.development.js
+++ b/webpack.config.development.js
@@ -7,9 +7,15 @@ config.devServer = {
       { from: /^\/$/, to: 'index.html' }
     ]
   },
+  host: '0.0.0.0',
   hot: true,
   inline: true,
-  host: '0.0.0.0'
+  proxy: {
+    '/api': {
+      changeOrigin: true,
+      target: 'http://localhost:3000'
+    }
+  }
 };
 config.devtool = 'inline-source-map';
 


### PR DESCRIPTION
#### Why
Because almost all our projects have to proxy to an API and it's usually at `localhost:3000`. I think having it will make development on FE projects easier.

#### What
- Added a proxy to the dev server