### PR TITLE
Updating to containerize the app for Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+.git/
+.gitignore
+README.md
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,27 @@
-FROM node:6
+# Use the slim version of the latest Node LTS which includes Yarn
+FROM node:6.10.2-slim
 
-RUN apt-get update
-RUN apt-get install apt-transport-https
+# Docker images have no default editor so we'll use vim
+RUN apt-get update && apt-get install -y \
+  vim
 
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+# Create an app directory for our app to exist in the docker container
+RUN mkdir -p app
 
-RUN apt-get update
-RUN apt-get install yarn
-
+# Establish a directory where later commands will be run relative to in the container
 WORKDIR /app
 
+# Copy package.json & yarn.lock into our app directory in the container
+COPY package.json \
+  yarn.lock \
+  # Destination folder
+  /app/
+
+# Install dependencies in the container
+RUN yarn install
+
+# Copy all the rest of our files into the app directory in the container
+COPY . /app
+
+# Expose port for webpack
 EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -33,14 +33,16 @@ git push origin master
 
 ## Commands
 
-Run your tests with:
-```
-yarn test
-```
 Run the server with:
 ```
 yarn start
 ```
+
+Run your tests with:
+```
+yarn test
+```
+
 Run a build with:
 ```
 yarn build
@@ -50,7 +52,7 @@ yarn build
 
 Build and start the server:
 ```
-docker-compose up
+docker-compose up --build
 ```
 
 Run your tests with:
@@ -61,4 +63,9 @@ docker-compose exec web yarn test
 Run a build with:
 ```
 docker-compose exec web yarn build
+```
+
+If your terminal closes run:
+```
+docker-compose logs --follow
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,8 @@ services:
   web:
     tty: true
     build: .
-    command: bash -c "yarn && yarn start"
+    command: 'yarn start'
     ports:
-      - '8080:8080'
+      - "8080:8080"
     volumes:
-      - .:/app:rw
+      - .:/app


### PR DESCRIPTION
# WHY?

The official docker NodeJS images include `yarn` so there is no longer a need to install it in the `Dockerfile`
References:
 - [1](https://github.com/docker-library/official-images/pull/2703)
 - [2](https://github.com/nodejs/docker-node/pull/337)
 - [3](https://github.com/docker-library/official-images/commits/master/library/node)

# WHAT?

- Remove the installation of `yarn` in the `Dockerfile (it's included in the Node images now)
- The previous `Dockerfile` would only work when you were running the service with `docker-compose` since you had a shared volume between your host machine and the container, but if you just tried to build the image and then tried to run it it would fail because in the build process no source code was moved into the container.
- Switched the `node` image to the latest LTS slim image.
- It's best practice to have the `apt-get update` and `apt-get install` on the same line concatenated with `&&` to take advantage of docker caching and proper cache-busting. Refer to the `Run` section [here](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#run).
- **Now you can develop without having to install anything locally (e.g. `node_modules`, `node`, `yarn`, etc.) except maybe `git` and a text editor**. 
- Added comments for clarity.