### PR TITLE
Chore/build updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "homepage": "https://github.com/smashingboxes/web-boilerplate#readme",
   "dependencies": {
     "axios": "^0.15.3",
+    "extract-text-webpack-plugin": "^2.1.0",
     "normalize.css": "^5.0.0",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "chai-enzyme": "^0.6.1",
     "cheerio": "^0.22.0",
     "clean-webpack-plugin": "^0.1.14",
-    "css-loader": "^0.26.1",
+    "css-loader": "^0.28.1",
     "enzyme": "^2.7.0",
     "es6-promise": "^4.0.5",
     "eslint": "^3.12.2",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "homepage": "https://github.com/smashingboxes/web-boilerplate#readme",
   "dependencies": {
     "axios": "^0.15.3",
+    "compression-webpack-plugin": "^0.4.0",
     "extract-text-webpack-plugin": "^2.1.0",
     "normalize.css": "^5.0.0",
     "react": "^15.4.1",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "A template for new front-end projects.",
   "main": "index.js",
   "scripts": {
-    "lint": "npm run lint:css && npm run lint:js",
-    "lint:css": "stylelint 'src/css/**/*.css' || true",
+    "lint": "npm run lint:css ; npm run lint:js",
+    "lint:css": "stylelint 'src/css/**/*.css'",
     "lint:js": "eslint --format 'node_modules/eslint-friendly-formatter' --ext .js,.jsx ./src",
     "lint:dev": "npm run lint -- -w",
     "test": "NODE_ENV=test mocha --compilers jsx:babel-register --opts 'support/mocha.opts' 'src/**/*.spec.*'",

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -22,13 +22,6 @@ module.exports = {
         options: { presets: ['stage-2', 'react', 'es2015'] }
       }
     }, {
-      test: /\.css$/,
-      use: [
-        'style-loader',
-        'css-loader?importLoaders=1',
-        'postcss-loader'
-      ]
-    }, {
       test: /\.(gif|png|jpg|svg|woff|woff2|ttf|eot)$/,
       use: {
         loader: 'url-loader',

--- a/webpack.config.development.js
+++ b/webpack.config.development.js
@@ -19,12 +19,22 @@ config.devServer = {
 };
 config.devtool = 'inline-source-map';
 
-config.module.rules = config.module.rules.concat([{
-  enforce: 'pre',
-  test: /\.jsx?$/,
-  exclude: /node_modules/,
-  use: 'eslint-loader'
-}]);
+config.module.rules = config.module.rules.concat([
+  {
+    enforce: 'pre',
+    test: /\.jsx?$/,
+    exclude: /node_modules/,
+    use: 'eslint-loader'
+  },
+  {
+    test: /\.css$/,
+    use: [
+      'style-loader',
+      'css-loader?importLoaders=1',
+      'postcss-loader'
+    ]
+  }
+]);
 
 config.plugins.unshift(new webpack.HotModuleReplacementPlugin());
 config.plugins.unshift(new webpack.LoaderOptionsPlugin({

--- a/webpack.config.development.js
+++ b/webpack.config.development.js
@@ -30,7 +30,13 @@ config.module.rules = config.module.rules.concat([
     test: /\.css$/,
     use: [
       'style-loader',
-      'css-loader?importLoaders=1',
+      {
+        loader: 'css-loader',
+        options: {
+          importLoaders: 1,
+          sourceMap: true
+        }
+      },
       'postcss-loader'
     ]
   }

--- a/webpack.config.production.js
+++ b/webpack.config.production.js
@@ -1,5 +1,6 @@
-var webpack = require('webpack');
+var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var InlineManifestWebpackPlugin = require('inline-manifest-webpack-plugin');
+var webpack = require('webpack');
 var config = require('./webpack.config.base');
 
 config.bail = true;
@@ -7,10 +8,24 @@ config.profile = false;
 config.devtool = 'source-map';
 config.output.filename = '[name].[chunkhash].js';
 
+config.module.rules = config.module.rules.concat([
+  {
+    test: /\.css$/,
+    use: ExtractTextPlugin.extract({
+      fallback: 'style-loader',
+      use: [
+        'css-loader?importLoaders=1',
+        'postcss-loader'
+      ]
+    })
+  }
+]);
+
 config.plugins = config.plugins.concat([
   new webpack.LoaderOptionsPlugin({
     debug: true
   }),
+  new ExtractTextPlugin('styles.[contenthash].css'),
   new webpack.optimize.CommonsChunkPlugin({
     name: 'vendor',
     minChunks: function(module) {

--- a/webpack.config.production.js
+++ b/webpack.config.production.js
@@ -13,7 +13,13 @@ config.module.rules = config.module.rules.concat([
     use: ExtractTextPlugin.extract({
       fallback: 'style-loader',
       use: [
-        'css-loader?importLoaders=1',
+        {
+          loader: 'css-loader',
+          options: {
+            importLoaders: 1,
+            minimize: true
+          }
+        },
         'postcss-loader'
       ]
     })

--- a/webpack.config.production.js
+++ b/webpack.config.production.js
@@ -1,3 +1,4 @@
+var CompressionPlugin = require('compression-webpack-plugin');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var InlineManifestWebpackPlugin = require('inline-manifest-webpack-plugin');
 var webpack = require('webpack');
@@ -30,6 +31,7 @@ config.plugins = config.plugins.concat([
   new webpack.LoaderOptionsPlugin({
     debug: true
   }),
+  new CompressionPlugin(),
   new ExtractTextPlugin('styles.[contenthash].css'),
   new webpack.optimize.CommonsChunkPlugin({
     name: 'vendor',

--- a/webpack.config.production.js
+++ b/webpack.config.production.js
@@ -5,7 +5,6 @@ var config = require('./webpack.config.base');
 
 config.bail = true;
 config.profile = false;
-config.devtool = 'source-map';
 config.output.filename = '[name].[chunkhash].js';
 
 config.module.rules = config.module.rules.concat([

--- a/yarn.lock
+++ b/yarn.lock
@@ -44,6 +44,13 @@ ajv-keywords@^1.0.0, ajv-keywords@^1.1.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.4.0.tgz#87db6a428bac4a5057a772fa83c6c22b6ec2768e"
 
+ajv@^4.11.2:
+  version "4.11.8"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
+  dependencies:
+    co "^4.6.0"
+    json-stable-stringify "^1.0.1"
+
 ajv@^4.7.0:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.10.1.tgz#6e1669b62d752424a73da9175901d0327adfc2a5"
@@ -2193,6 +2200,15 @@ extglob@^0.3.1:
   dependencies:
     is-extglob "^1.0.0"
 
+extract-text-webpack-plugin@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/extract-text-webpack-plugin/-/extract-text-webpack-plugin-2.1.0.tgz#69315b885f876dbf96d3819f6a9f1cca7aebf159"
+  dependencies:
+    ajv "^4.11.2"
+    async "^2.1.2"
+    loader-utils "^1.0.2"
+    webpack-sources "^0.1.0"
+
 extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
@@ -3225,6 +3241,14 @@ loader-utils@0.2.x, loader-utils@^0.2.11, loader-utils@^0.2.16, loader-utils@^0.
     emojis-list "^2.0.0"
     json5 "^0.5.0"
     object-assign "^4.0.1"
+
+loader-utils@^1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.1.0.tgz#c98aef488bcceda2ffb5e2de646d6a754429f5cd"
+  dependencies:
+    big.js "^3.1.3"
+    emojis-list "^2.0.0"
+    json5 "^0.5.0"
 
 lodash-es@^4.2.0, lodash-es@^4.2.1:
   version "4.17.2"
@@ -5298,7 +5322,7 @@ sortobject@^1.0.0:
   dependencies:
     editions "^1.1.1"
 
-source-list-map@^0.1.4:
+source-list-map@^0.1.4, source-list-map@~0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-0.1.7.tgz#d4b5ce2a46535c72c7e8527c71a77d250618172e"
 
@@ -5964,6 +5988,13 @@ webpack-hot-middleware@^2.16.1:
     html-entities "^1.2.0"
     querystring "^0.2.0"
     strip-ansi "^3.0.0"
+
+webpack-sources@^0.1.0:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-0.1.5.tgz#aa1f3abf0f0d74db7111c40e500b84f966640750"
+  dependencies:
+    source-list-map "~0.1.7"
+    source-map "~0.5.3"
 
 webpack-sources@^0.2.3:
   version "0.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -44,16 +44,9 @@ ajv-keywords@^1.0.0, ajv-keywords@^1.1.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-1.4.0.tgz#87db6a428bac4a5057a772fa83c6c22b6ec2768e"
 
-ajv@^4.11.2:
+ajv@^4.11.2, ajv@^4.7.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
-  dependencies:
-    co "^4.6.0"
-    json-stable-stringify "^1.0.1"
-
-ajv@^4.7.0:
-  version "4.10.1"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.10.1.tgz#6e1669b62d752424a73da9175901d0327adfc2a5"
   dependencies:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
@@ -1519,14 +1512,14 @@ css-color-names@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
 
-css-loader@^0.26.1:
-  version "0.26.1"
-  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-0.26.1.tgz#2ba7f20131b93597496b3e9bb500785a49cd29ea"
+css-loader@^0.28.1:
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-0.28.1.tgz#220325599f8f00452d9ceb4c3ca6c8a66798642d"
   dependencies:
     babel-code-frame "^6.11.0"
     css-selector-tokenizer "^0.7.0"
     cssnano ">=2.6.1 <4"
-    loader-utils "~0.2.2"
+    loader-utils "^1.0.2"
     lodash.camelcase "^4.3.0"
     object-assign "^4.0.1"
     postcss "^5.0.6"
@@ -1534,7 +1527,8 @@ css-loader@^0.26.1:
     postcss-modules-local-by-default "^1.0.1"
     postcss-modules-scope "^1.0.0"
     postcss-modules-values "^1.1.0"
-    source-list-map "^0.1.4"
+    postcss-value-parser "^3.3.0"
+    source-list-map "^0.1.7"
 
 css-rule-stream@^1.1.0:
   version "1.1.0"
@@ -3233,7 +3227,7 @@ loader-runner@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.3.0.tgz#f482aea82d543e07921700d5a46ef26fdac6b8a2"
 
-loader-utils@0.2.x, loader-utils@^0.2.11, loader-utils@^0.2.16, loader-utils@^0.2.7, loader-utils@~0.2.2, loader-utils@~0.2.5:
+loader-utils@0.2.x, loader-utils@^0.2.11, loader-utils@^0.2.16, loader-utils@^0.2.7, loader-utils@~0.2.5:
   version "0.2.16"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-0.2.16.tgz#f08632066ed8282835dff88dfb52704765adee6d"
   dependencies:
@@ -4619,7 +4613,7 @@ postcss-zindex@^2.0.1:
     postcss "^5.0.4"
     uniqs "^2.0.0"
 
-postcss@^5.0.0, postcss@^5.0.12, postcss@^5.0.14, postcss@^5.0.4, postcss@^5.0.6, postcss@^5.2.0:
+postcss@^5.0.0, postcss@^5.0.12, postcss@^5.0.14, postcss@^5.0.4, postcss@^5.2.0:
   version "5.2.6"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.6.tgz#a252cd67cd52585035f17e9ad12b35137a7bdd9e"
   dependencies:
@@ -4628,7 +4622,7 @@ postcss@^5.0.0, postcss@^5.0.12, postcss@^5.0.14, postcss@^5.0.4, postcss@^5.0.6
     source-map "^0.5.6"
     supports-color "^3.1.2"
 
-postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.13, postcss@^5.0.16, postcss@^5.0.18, postcss@^5.0.19, postcss@^5.0.2, postcss@^5.0.20, postcss@^5.0.21, postcss@^5.0.3, postcss@^5.0.5, postcss@^5.0.8, postcss@^5.1.1, postcss@^5.2.4, postcss@^5.2.5, postcss@^5.2.6, postcss@^5.2.9:
+postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.13, postcss@^5.0.16, postcss@^5.0.18, postcss@^5.0.19, postcss@^5.0.2, postcss@^5.0.20, postcss@^5.0.21, postcss@^5.0.3, postcss@^5.0.5, postcss@^5.0.6, postcss@^5.0.8, postcss@^5.1.1, postcss@^5.2.4, postcss@^5.2.5, postcss@^5.2.6, postcss@^5.2.9:
   version "5.2.12"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.12.tgz#6a2b15e35dd65634441bb0961fa796904c7890e0"
   dependencies:
@@ -5322,7 +5316,7 @@ sortobject@^1.0.0:
   dependencies:
     editions "^1.1.1"
 
-source-list-map@^0.1.4, source-list-map@~0.1.7:
+source-list-map@^0.1.7, source-list-map@~0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-0.1.7.tgz#d4b5ce2a46535c72c7e8527c71a77d250618172e"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -209,6 +209,10 @@ async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
 
+async@0.2.x:
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/async/-/async-0.2.10.tgz#b6bbe0b0674b9d719708ca38de8c237cb526c3d1"
+
 async@^1.5.0, async@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
@@ -1347,7 +1351,7 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2.9.0, commander@2.9.x, commander@^2.9.0:
+commander@2.9.0, commander@2.9.x, commander@^2.8.1, commander@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
   dependencies:
@@ -1362,6 +1366,15 @@ compressible@~2.0.8:
   resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.9.tgz#6daab4e2b599c2770dd9e21e7a891b1c5a755425"
   dependencies:
     mime-db ">= 1.24.0 < 2"
+
+compression-webpack-plugin@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/compression-webpack-plugin/-/compression-webpack-plugin-0.4.0.tgz#811de04215f811ea6a12d4d8aed8457d758f13ac"
+  dependencies:
+    async "0.2.x"
+    webpack-sources "^0.1.0"
+  optionalDependencies:
+    node-zopfli "^2.0.0"
 
 compression@^1.5.2:
   version "1.6.2"
@@ -1687,6 +1700,12 @@ deep-extend@~0.4.0:
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
+
+defaults@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"
+  dependencies:
+    clone "^1.0.2"
 
 define-properties@^1.1.2:
   version "1.1.2"
@@ -3606,7 +3625,7 @@ mute-stream@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
 
-nan@^2.3.0:
+nan@^2.0.0, nan@^2.3.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.5.0.tgz#aa8f1e34531d807e9e27755b234b4a6ec0c152a8"
 
@@ -3665,7 +3684,7 @@ node-libs-browser@^2.0.0:
     util "^0.10.3"
     vm-browserify "0.0.4"
 
-node-pre-gyp@^0.6.29:
+node-pre-gyp@^0.6.29, node-pre-gyp@^0.6.4:
   version "0.6.32"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.32.tgz#fc452b376e7319b3d255f5f34853ef6fd8fe1fd5"
   dependencies:
@@ -3678,6 +3697,15 @@ node-pre-gyp@^0.6.29:
     semver "~5.3.0"
     tar "~2.2.1"
     tar-pack "~3.3.0"
+
+node-zopfli@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/node-zopfli/-/node-zopfli-2.0.2.tgz#a7a473ae92aaea85d4c68d45bbf2c944c46116b8"
+  dependencies:
+    commander "^2.8.1"
+    defaults "^1.0.2"
+    nan "^2.0.0"
+    node-pre-gyp "^0.6.4"
 
 nopt@~3.0.6:
   version "3.0.6"
@@ -4613,16 +4641,7 @@ postcss-zindex@^2.0.1:
     postcss "^5.0.4"
     uniqs "^2.0.0"
 
-postcss@^5.0.0, postcss@^5.0.12, postcss@^5.0.14, postcss@^5.0.4, postcss@^5.2.0:
-  version "5.2.6"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.6.tgz#a252cd67cd52585035f17e9ad12b35137a7bdd9e"
-  dependencies:
-    chalk "^1.1.3"
-    js-base64 "^2.1.9"
-    source-map "^0.5.6"
-    supports-color "^3.1.2"
-
-postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.13, postcss@^5.0.16, postcss@^5.0.18, postcss@^5.0.19, postcss@^5.0.2, postcss@^5.0.20, postcss@^5.0.21, postcss@^5.0.3, postcss@^5.0.5, postcss@^5.0.6, postcss@^5.0.8, postcss@^5.1.1, postcss@^5.2.4, postcss@^5.2.5, postcss@^5.2.6, postcss@^5.2.9:
+postcss@^5.0.0, postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0.14, postcss@^5.0.16, postcss@^5.0.18, postcss@^5.0.19, postcss@^5.0.2, postcss@^5.0.20, postcss@^5.0.21, postcss@^5.0.3, postcss@^5.0.4, postcss@^5.0.5, postcss@^5.0.6, postcss@^5.0.8, postcss@^5.1.1, postcss@^5.2.0, postcss@^5.2.4, postcss@^5.2.5, postcss@^5.2.6, postcss@^5.2.9:
   version "5.2.12"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.12.tgz#6a2b15e35dd65634441bb0961fa796904c7890e0"
   dependencies:
@@ -5589,7 +5608,7 @@ sugarss@^0.2.0:
   dependencies:
     postcss "^5.2.4"
 
-supports-color@3.1.2, supports-color@^3.1.0, supports-color@^3.1.1, supports-color@^3.1.2:
+supports-color@3.1.2, supports-color@^3.1.0, supports-color@^3.1.1:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.1.2.tgz#72a262894d9d408b956ca05ff37b2ed8a6e2a2d5"
   dependencies:


### PR DESCRIPTION
## Why?
There's some stuff that we need for our builds that we haven't added to this boilerplate yet.

## What changed?
- No longer use `style-loader` in production (allows us to avoid a FOUC)
- Minimizes the CSS in production builds
- GZIPs bundle and style files in production builds
- Enables CSS sourcemaps so things look nicer in the developer tools
- Adjusts the lint npm task so that errors in CSS will cause the build to fail (previously would output them and continue on like its okay)