### PR TITLE
Fix a bug with non-401 errors

### DIFF
--- a/modules/authentication/Interceptors.js
+++ b/modules/authentication/Interceptors.js
@@ -30,6 +30,8 @@ class Interceptors {
     if (error.response.status === 401) {
       const store = this.store.getStore();
       store.dispatch(clearHeaders());
+    } else {
+      this.saveTokenInfo(error.response);
     }
 
     throw error;

--- a/modules/authentication/Interceptors.spec.js
+++ b/modules/authentication/Interceptors.spec.js
@@ -125,8 +125,9 @@ describe('authentication/Interceptors', function() {
 
       const saveTokenInfo = this.sandbox.stub(
         Interceptors.prototype,
-        'saveTokenInfo'
-      ).callsFake(() => {});
+        'saveTokenInfo',
+        () => {}
+      );
 
       expect(() => {
         interceptors.invalidateHeaders(expectedError);

--- a/modules/authentication/Interceptors.spec.js
+++ b/modules/authentication/Interceptors.spec.js
@@ -121,11 +121,18 @@ describe('authentication/Interceptors', function() {
 
     it('does not dispatch a sign out action on a non-401 error', function() {
       const expectedError = new Error();
-      expectedError.response = {};
+      expectedError.response = { status: 422 };
+
+      const saveTokenInfo = this.sandbox.stub(
+        Interceptors.prototype,
+        'saveTokenInfo'
+      ).callsFake(() => {});
+
       expect(() => {
         interceptors.invalidateHeaders(expectedError);
       }).to.throw(expectedError);
 
+      expect(saveTokenInfo.calledOnce).to.be.true;
       expect(dispatch.called).to.be.false;
     });
   });


### PR DESCRIPTION
### Why?

On backend non-401 errors (eg 422), users were being logged out.

### What changed?

Added a missing `else` case for the `invalidateHeaders` interceptor. Basically, what was happening is when a 422 occurred, that function would get called (instead of `saveTokenInfo`). Since it wasn't a 401, it wouldn't log us out yet, but it also wouldn't save the response tokens. So on the next request, we'd send an old token, and the BE would 401, and we'd be kicked out.