### PR TITLE
Add constants folder with actionTypes file

### DIFF
--- a/src/actions/helloWorldActions.js
+++ b/src/actions/helloWorldActions.js
@@ -1,6 +1,8 @@
+import actionTypes from '../constants/actionTypes';
+
 function setName(name) {
   return {
-    type: 'SET_NAME',
+    type: actionTypes.SET_NAME,
     payload: {
       name
     }

--- a/src/actions/helloWorldActions.spec.js
+++ b/src/actions/helloWorldActions.spec.js
@@ -1,13 +1,14 @@
 import faker from 'faker';
 
 import * as actions from './helloWorldActions';
+import actionTypes from '../constants/actionTypes';
 
 describe('Hello World Actions', () => {
   describe('#setName', () => {
     it('should return an action to set the name', () => {
       const name = faker.name.firstName();
       expect(actions.setName(name)).to.eql({
-        type: 'SET_NAME',
+        type: actionTypes.SET_NAME,
         payload: { name }
       });
     });

--- a/src/constants/actionTypes.js
+++ b/src/constants/actionTypes.js
@@ -1,0 +1,5 @@
+import keyMirror from 'keymirror';
+
+export default keyMirror({
+  SET_NAME: null
+});

--- a/src/reducers/helloWorldReducer.js
+++ b/src/reducers/helloWorldReducer.js
@@ -1,10 +1,12 @@
+import actionTypes from '../constants/actionTypes';
+
 const INITIAL_STATE = {
   name: 'World'
 };
 
 function reducer(state = INITIAL_STATE, action) {
   switch (action.type) {
-  case 'SET_NAME':
+  case actionTypes.SET_NAME:
     return {
       ...state,
       name: action.payload.name

--- a/src/reducers/helloWorldReducer.spec.js
+++ b/src/reducers/helloWorldReducer.spec.js
@@ -1,4 +1,5 @@
 import helloWorldReducer from './helloWorldReducer';
+import actionTypes from '../constants/actionTypes';
 
 describe('helloWorldReducer', function() {
   const INITIAL_STATE = { name: 'World' };
@@ -18,7 +19,7 @@ describe('helloWorldReducer', function() {
   describe('SET_NAME action', function() {
     const name = faker.name.firstName();
     const action = {
-      type: 'SET_NAME',
+      type: actionTypes.SET_NAME,
       payload: { name }
     };
     const expected = { name };


### PR DESCRIPTION
## Why?

Issue https://github.com/smashingboxes/web-boilerplate/issues/64

Create a `constants` director with an initial `actionTypes.js` folder in the `src` directory

## What Changed?
- Added a `constants` directory inside `src`
- Added an `actionTypes.js` file
- Updated relevant actions and reducers

## Once Merged
I will update the issue referenced in the Why section

## More updates to come. Take a look at the Issue referenced in Why