### PR TITLE
Updates: Install prop-types package, upgrade other package

### DIFF
--- a/modules/authentication/components/ForgotPassword.jsx
+++ b/modules/authentication/components/ForgotPassword.jsx
@@ -1,8 +1,8 @@
 import React, {
   cloneElement,
-  Component,
-  PropTypes
+  Component
 } from 'react';
+import PropTypes from 'prop-types';
 import mapFormValues from '../utils/mapFormValues';
 
 const propTypes = {

--- a/modules/authentication/components/Register.jsx
+++ b/modules/authentication/components/Register.jsx
@@ -1,8 +1,8 @@
 import React, {
   cloneElement,
-  Component,
-  PropTypes
+  Component
 } from 'react';
+import PropTypes from 'prop-types';
 import mapFormValues from '../utils/mapFormValues';
 
 const propTypes = {

--- a/modules/authentication/components/RegistrationConfirmed.jsx
+++ b/modules/authentication/components/RegistrationConfirmed.jsx
@@ -1,8 +1,8 @@
 import React, {
   cloneElement,
-  Component,
-  PropTypes
+  Component
 } from 'react';
+import PropTypes from 'prop-types';
 import {
   Link
 } from 'react-router';

--- a/modules/authentication/components/ResetPassword.jsx
+++ b/modules/authentication/components/ResetPassword.jsx
@@ -1,8 +1,8 @@
 import React, {
   cloneElement,
-  Component,
-  PropTypes
+  Component
 } from 'react';
+import PropTypes from 'prop-types';
 import mapFormValues from '../utils/mapFormValues';
 
 const propTypes = {

--- a/modules/authentication/components/SignIn.jsx
+++ b/modules/authentication/components/SignIn.jsx
@@ -1,8 +1,8 @@
 import React, {
   cloneElement,
-  Component,
-  PropTypes
+  Component
 } from 'react';
+import PropTypes from 'prop-types';
 import mapFormValues from '../utils/mapFormValues';
 
 const propTypes = {

--- a/modules/authentication/components/SignOut.jsx
+++ b/modules/authentication/components/SignOut.jsx
@@ -1,6 +1,5 @@
-import React, {
-  PropTypes
-} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 const propTypes = {
   actions: PropTypes.shape({

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "extract-text-webpack-plugin": "^3.0.2",
     "faker": "^3.1.0",
     "file-loader": "^0.9.0",
-    "html-webpack-plugin": "^2.28.0",
+    "html-webpack-plugin": "^2.30.1",
     "inline-manifest-webpack-plugin": "^3.0.1",
     "json-loader": "^0.5.4",
     "lolex": "^1.5.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "axios": "^0.15.3",
     "keymirror": "^0.1.1",
     "normalize.css": "^5.0.0",
+    "prop-types": "^15.6.0",
     "react": "^15.4.1",
     "react-dom": "^15.4.1",
     "react-redux": "^5.0.1",

--- a/src/Routes.jsx
+++ b/src/Routes.jsx
@@ -1,6 +1,5 @@
-import React, {
-  PropTypes
-} from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import {
   browserHistory as history,
   IndexRoute,

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 import Greeting from './Greeting';
 import NameTaker from './NameTaker';

--- a/src/components/Greeting.jsx
+++ b/src/components/Greeting.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 const propTypes = {
   name: PropTypes.string

--- a/src/components/NameTaker.jsx
+++ b/src/components/NameTaker.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 const propTypes = {
   name: PropTypes.string,

--- a/src/components/NameTaker.jsx
+++ b/src/components/NameTaker.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 const propTypes = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2580,6 +2580,18 @@ fbjs@^0.8.1, fbjs@^0.8.4:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
+fbjs@^0.8.16:
+  version "0.8.16"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
+
 figures@^1.3.5:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
@@ -3621,6 +3633,10 @@ js-tokens@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-2.0.0.tgz#79903f5563ee778cc1162e6dcf1a0027c97f9cb5"
 
+js-tokens@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
+
 js-yaml@^3.4.3, js-yaml@^3.5.1:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.7.0.tgz#5c967ddd837a9bfdca5f2de84253abe8a1c03b80"
@@ -4040,6 +4056,12 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0:
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.0.tgz#6b26248c42f6d4fa4b0d8542f78edfcde35642a8"
   dependencies:
     js-tokens "^2.0.0"
+
+loose-envify@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
+  dependencies:
+    js-tokens "^3.0.0"
 
 loud-rejection@^1.0.0:
   version "1.6.0"
@@ -4464,6 +4486,10 @@ oauth-sign@~0.8.1:
 object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.0.tgz#7a3b3d0e98063d43f4c03f2e8ae6cd51a86883a0"
+
+object-assign@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
 object-copy@^0.1.0:
   version "0.1.0"
@@ -5495,6 +5521,14 @@ promise@^7.1.1:
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.1.1.tgz#489654c692616b8aa55b0724fa809bb7db49c5bf"
   dependencies:
     asap "~2.0.3"
+
+prop-types@^15.6.0:
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
 
 proxy-addr@~2.0.2:
   version "2.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3109,9 +3109,9 @@ html-tags@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-1.1.1.tgz#869f43859f12d9bdc3892419e494a628aa1b204e"
 
-html-webpack-plugin@^2.28.0:
-  version "2.28.0"
-  resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-2.28.0.tgz#2e7863b57e5fd48fe263303e2ffc934c3064d009"
+html-webpack-plugin@^2.30.1:
+  version "2.30.1"
+  resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-2.30.1.tgz#7f9c421b7ea91ec460f56527d78df484ee7537d5"
   dependencies:
     bluebird "^3.4.7"
     html-minifier "^3.2.3"


### PR DESCRIPTION
## Why?

Issue https://github.com/smashingboxes/web-boilerplate/issues/64

Upgrade packages, install packages

## What Changed?
- Installed `prop-types` package
- Changed `import`ing `PropTypes` from the `react` package to `prop-types`
- Upgrade `html-webpack-plugin` package
    - Due to upgrading `webpack` to v3 we were having an incorrect peer dependency for `html-webpack-plugin@2.28.0`
    - You can see in the [CHANGELOG](https://github.com/jantimon/html-webpack-plugin/blob/master/CHANGELOG.md#v2290) that support for `webpack` v3 was added starting in v2.29.0

## Once Merged
I will update the issue referenced in the Why section

## More updates to come. Take a look at the Issue referenced in Why