### PR TITLE
Add publicPath key and value to output in webpack config

### DIFF
--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -11,7 +11,8 @@ module.exports = {
   },
   output: {
     path: path.join(__dirname, 'dist'),
-    filename: '[name].js'
+    filename: '[name].js',
+    publicPath: '/'
   },
   module: {
     rules: [{


### PR DESCRIPTION
## Why?

Not having `publicPath` equal to `'/'` would break when trying to go to nested routes

## What Changed?
- Added `publicPath: '/'` to the config
