### PR TITLE
Remove presets in webpack config, fix whitespacing

### DIFF
--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -15,22 +15,24 @@ module.exports = {
     publicPath: '/'
   },
   module: {
-    rules: [{
-      test: /\.jsx?$/,
-      exclude: /node_modules/,
-      use: {
-        loader: 'babel-loader',
-        options: { presets: ['stage-2', 'react', 'es2015'] }
-      }
-    }, {
-      test: /\.(gif|png|jpg|svg|woff|woff2|ttf|eot)$/,
-      use: {
-        loader: 'url-loader',
-        options: {
-          limit: 25000
+    rules: [
+      {
+        test: /\.jsx?$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader'
+        }
+      },
+      {
+        test: /\.(gif|png|jpg|svg|woff|woff2|ttf|eot)$/,
+        use: {
+          loader: 'url-loader',
+          options: {
+            limit: 25000
+          }
         }
       }
-    }]
+    ]
   },
   plugins: [
     new webpack.NamedModulesPlugin(),


### PR DESCRIPTION
## Why?

We already have a `.babelrc` file you can see [here](https://github.com/smashingboxes/web-boilerplate/blob/master/.babelrc), we don't need presets specified in `webpack` config

## What Changed?
- Removed the `options` and `presets` from the webpack config file
- Fixed some white-spacing/indentation
